### PR TITLE
Benchmarks and documentation

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - master
+      - 'docs'
 
 jobs:
   stack-build:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,8 +11,8 @@ on:
       - master
 
 env:
-  DOCS_DIR: ${{ github.workspace }}/docs
   DOCS_BRANCH: docs
+  DOCS_DIR: ${{ github.workspace }}/docs
 
 jobs:
   stack-build:
@@ -40,13 +40,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
     - run: cabal update
+
     - run: cabal configure --enable-tests
+
     - run: cabal build
+
     - run: cabal test --test-show-details=always
-    - run: cabal haddock
+
     - run: cabal check
+
     - run: cabal sdist
+
+    - name: Run cabal haddock
+      run: |
+        cabal haddock
+        echo "HADDOC_DIR=$(find . -type d -name 'fixed-decimal')" >> $GITHUB_ENV
+
+    - name: Upload Haddock documentation
+      uses: actions/upload-artifact@v3
+      with:
+        name: haddock
+        path: |
+          ${{ env.HADDOC_DIR }}/**/*
 
   metrics:
     runs-on: ubuntu-latest
@@ -101,6 +118,7 @@ jobs:
 
   documentation:
     needs:
+      - cabal-build
       - benchmarks
     runs-on: ubuntu-latest
     steps:    

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - master
 
+env:
+  DOCS_DIR: ${{ github.workspace }}/docs
+  DOCS_BRANCH: docs
+
 jobs:
   stack-build:
     strategy:
@@ -51,21 +55,89 @@ jobs:
       LCOV_PATH: ./lcov.info
     steps:
     - uses: actions/checkout@v4
+
     - name: Add $HOME/.local/bin to PATH
       run: echo "::add-path::$HOME/.local/bin"
+
     - name: Run tests with coverage
       run: stack test --coverage
+
     - name: Install hpc-lcov
       run: stack install hpc-lcov
+
     - name: Convert coverage results to LCOV format
       run: hpc-lcov -o ${{ env.LCOV_PATH }}
+
     - name: Upload coverage to Coverall 
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ${{ env.LCOV_PATH }}
+
+  benchmarks:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    env:
+      BENCH_DIR: .bench
+    steps:
+    - uses: actions/checkout@v4
+
     - name: Run benchmarks
-      run: stack bench
+      run: |
+        mkdir ${{ env.BENCH_DIR }}
+        stack bench --ba '--csv ${{ env.BENCH_DIR }}/results.csv --svg ${{ env.BENCH_DIR }}/results.svg +RTS -T'
+
+    - name: Upload ${{ matrix.os }} benchmarks results
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.os }}
+        path: |
+          ${{ env.BENCH_DIR }}/**/*
+
+  documentation:
+    needs:
+      - benchmarks
+    runs-on: ubuntu-latest
+    steps:    
+    - name: Check out ${{ env.DOCS_BRANCH }} branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ env.DOCS_BRANCH }}
+
+    - name: Set version
+      run: |
+        echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+
+    - name: Clear up ${{ env.DOCS_DIR }} directory
+      run: |
+        git rm -r ${{ env.DOCS_DIR }}
+        mkdir ${{ env.DOCS_DIR }}
+
+    - name: Download benchmark results
+      uses: actions/download-artifact@v3
+      with:
+        path: ${{ env.DOCS_DIR }}
+
+    - name: Update documentation
+      run: |
+        npm i -g badge-maker
+        badge version "${{ env.VERSION }}" :green > "${{ env.DOCS_DIR }}/version.svg"
+        badge bench-linux "${{ env.VERSION }}" "#E95420" > "${{ env.DOCS_DIR }}/bench-linux.svg"
+        badge bench-windows "${{ env.VERSION }}" "#01BCF3" > "${{ env.DOCS_DIR }}/bench-windows.svg"
+        git add ${{ env.DOCS_DIR }}/*
+        git -c "user.name=Auto Publisher" -c "user.email=eduard.sergeev@gmail.com" commit --allow-empty -m "Build ${{ env.VERSION }}"
+
+    - name: Push documentation to '${{ env.DOCS_BRANCH }}' branch
+      if: github.event_name == 'push' && startsWith(github.event.base_ref, 'refs/heads/master') && startsWith(github.event.ref, 'refs/tags')
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ env.DOCS_BRANCH }}
 
   hackage-upload:
     if: github.event_name == 'push' && startsWith(github.event.base_ref, 'refs/heads/master') && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -38,8 +38,14 @@ jobs:
 
   cabal-build:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract-version.outputs.VERSION }}
     steps:
     - uses: actions/checkout@v4
+
+    - name: Extract package version
+      id: extract-version
+      run: echo "VERSION=$(grep '^version' fixed-decimal.cabal | grep -Po '[0-9.]*')" >> $GITHUB_OUTPUT
 
     - run: cabal update
 
@@ -121,27 +127,25 @@ jobs:
       - cabal-build
       - benchmarks
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.cabal-build.outputs.version }}    
     steps:    
     - name: Check out ${{ env.DOCS_BRANCH }} branch
       uses: actions/checkout@v4
       with:
         ref: ${{ env.DOCS_BRANCH }}
 
-    - name: Set version
-      run: |
-        echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
-
     - name: Clear up ${{ env.DOCS_DIR }} directory
       run: |
         git rm -r ${{ env.DOCS_DIR }}
         mkdir ${{ env.DOCS_DIR }}
 
-    - name: Download benchmark results
+    - name: Download benchmarks results
       uses: actions/download-artifact@v3
       with:
         path: ${{ env.DOCS_DIR }}
 
-    - name: Update documentation
+    - name: Update documentation (version ${{ env.VERSION }})
       run: |
         npm i -g badge-maker
         badge version "${{ env.VERSION }}" :green > "${{ env.DOCS_DIR }}/version.svg"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -19,11 +19,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
         lts:
           - 18.28 # 8.10.7
           - 19.33 # 9.0.2
           - 22.24 # 9.6.5 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
 
@@ -104,11 +107,19 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     env:
       BENCH_DIR: .bench
     steps:
     - uses: actions/checkout@v4
+
+    - name: Install Haskell Stack
+      if: runner.os == 'macOS'
+      run: |
+        brew install llvm@12
+        echo "/opt/homebrew/opt/llvm@12/bin" >> $GITHUB_PATH
+        brew install haskell-stack
 
     - name: Run benchmarks
       run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -163,6 +163,7 @@ jobs:
       - stack-build
       - cabal-build
       - metrics
+      - benchmarks
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [![Build Status](https://github.com/EduardSergeev/fixed-decimal/actions/workflows/master.yml/badge.svg?branch=master)](https://github.com/EduardSergeev/fixed-decimal/actions?query=workflow%3Amaster+branch%3Amaster)
 [![Test Coverage](https://coveralls.io/repos/github/EduardSergeev/fixed-decimal/badge.svg)](https://coveralls.io/github/EduardSergeev/fixed-decimal)
+[![Documentation](https://eduardsergeev.github.io/fixed-decimal/version.svg)](https://eduardsergeev.github.io/fixed-decimal/haddock/)
 
 
 Fixed precision decimals for Haskell
+
+# Benchmarks
+
+[![Linux benchmarks](https://eduardsergeev.github.io/fixed-decimal/bench-linux.svg)](https://eduardsergeev.github.io/fixed-decimal/ubuntu-latest/results.svg)
+[![Windows benchmarks](https://eduardsergeev.github.io/fixed-decimal/bench-windows.svg)](https://eduardsergeev.github.io/fixed-decimal/windows-latest/results.svg)

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+
+import           Control.Arrow ((&&&))
+import           Control.DeepSeq (NFData)
+import qualified Data.Decimal as DD
+import           Data.DoubleWord
+import qualified Data.Fixed.Decimal as FD
+import           Data.List (foldl')
+import           Test.Tasty.Bench
+import           Text.Printf (printf)
+
+
+
+benchmarks :: [Benchmark]
+benchmarks =
+    fmap (uncurry benchmark . (show &&& id))  [
+        1000
+    ]
+
+benchmark :: String -> Int -> Benchmark
+benchmark t n =
+    bgroup t [
+        bgroup "Data.Fixed.Decimal" [
+            group "Decimal Int128 10" n (0.001 :: FD.Decimal Int128 10),
+            group "Decimal Int256 10" n (0.001 :: FD.Decimal Int256 10)
+        ],
+        group "Data.Decimal" n (0.001 :: DD.Decimal),
+        group "Double" n (0.001 :: Double)
+    ]
+
+group :: (NFData a, Fractional a) => String -> Int -> a -> Benchmark
+group t n d =
+    bgroup t [
+        bdef "+" $
+            nf (\n' -> sum $ replicate n' d) n,
+        bdef "-" $
+            nf (\n' -> foldl' (-) (fromIntegral n' * d) $ replicate n' d) n,
+        bdef "*" $
+            nf (\n' -> product $ replicate n' d) n,
+        bdef "/" $        
+            nf (\n' -> foldl' (/) (d ^ n') $ replicate n' d) n
+    ]
+    where
+        bdef o =
+            bench $ printf "%s (%dx times)" o n
+
+
+deriving instance NFData p => NFData (FD.Decimal p s)
+
+instance NFData Int256 where
+
+instance NFData Int128 where
+
+instance NFData Word128 where
+
+
+main :: IO ()
+main =
+    defaultMain benchmarks

--- a/fixed-decimal.cabal
+++ b/fixed-decimal.cabal
@@ -3,7 +3,20 @@ cabal-version: 2.2
 name:           fixed-decimal
 version:        0.0.0.1
 synopsis:       Fixed precision decimals for Haskell
-description:    Please see the README on GitHub at <https://github.com/EduardSergeev/fixed-decimal#readme>
+description:
+  Fixed precision decimal numbers type
+  .
+  Example of defining 256-bit signed decimal with 10-digit fractional part:
+  .
+  >{-# LANGUAGE DataKinds #-}
+  >
+  >import Data.DoubleWord (Int256)
+  >import Data.Fixed.Decimal as (Decimal)
+  >
+  >type DecimalI256 = Decimal Int256 10
+  .
+  
+
 category:       Data
 homepage:       https://github.com/EduardSergeev/fixed-decimal#readme
 bug-reports:    https://github.com/EduardSergeev/fixed-decimal/issues

--- a/fixed-decimal.cabal
+++ b/fixed-decimal.cabal
@@ -38,7 +38,7 @@ library
 
 test-suite fixed-decimal-test
   type: exitcode-stdio-1.0
-  main-is: Spec.hs
+  main-is: Main.hs
   other-modules:
       Paths_fixed_decimal
   autogen-modules:
@@ -48,11 +48,13 @@ test-suite fixed-decimal-test
   ghc-options: -Wall -fno-warn-orphans -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , data-dword >= 0.3 && < 0.5
+    , data-dword
     , Decimal
     , fixed-decimal
-    , hspec
     , QuickCheck
     , quickcheck-instances
     , scientific
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
   default-language: Haskell2010

--- a/fixed-decimal.cabal
+++ b/fixed-decimal.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:           fixed-decimal
-version:        0.0.0.1
+version:        0.0.1
 synopsis:       Fixed precision decimals for Haskell
 description:
   Fixed precision decimal numbers type

--- a/fixed-decimal.cabal
+++ b/fixed-decimal.cabal
@@ -21,40 +21,63 @@ source-repository head
   type: git
   location: https://github.com/EduardSergeev/fixed-decimal
 
-library
-  exposed-modules:
-      Data.Fixed.Decimal
-      Data.Fixed.Decimal.Class
-  other-modules:
-      Paths_fixed_decimal
-  autogen-modules:
-      Paths_fixed_decimal
-  hs-source-dirs:
-      src
-  ghc-options: -Wall -fno-warn-orphans -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
+common project-config
+  ghc-options:
+    -O2 -Wall
+  default-extensions:
+    DataKinds
+    FlexibleInstances
+    TypeApplications
   build-depends:
-      base >=4.7 && <5
+    base >=4.7 && <5
   default-language: Haskell2010
 
-test-suite fixed-decimal-test
-  type: exitcode-stdio-1.0
-  main-is: Main.hs
+library
+  import: project-config
+  exposed-modules:
+    Data.Fixed.Decimal
+    Data.Fixed.Decimal.Class
   other-modules:
-      Paths_fixed_decimal
+    Paths_fixed_decimal
   autogen-modules:
-      Paths_fixed_decimal
+    Paths_fixed_decimal
   hs-source-dirs:
-      test
-  ghc-options: -Wall -fno-warn-orphans -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+    src
+
+test-suite fixed-decimal-test
+  import: project-config
+  type: exitcode-stdio-1.0
+  main-is: Test.hs
+  other-modules:
+    Paths_fixed_decimal
+  autogen-modules:
+    Paths_fixed_decimal
+  hs-source-dirs:
+    test
+  ghc-options: -fno-warn-orphans -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
-    , data-dword
-    , Decimal
-    , fixed-decimal
-    , QuickCheck
-    , quickcheck-instances
-    , scientific
-    , tasty
-    , tasty-hunit
-    , tasty-quickcheck
-  default-language: Haskell2010
+    data-dword,
+    Decimal,
+    fixed-decimal,
+    QuickCheck,
+    quickcheck-instances,
+    scientific,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck
+
+benchmark all
+  import: project-config
+  type: exitcode-stdio-1.0
+  ghc-options:
+    -fno-warn-orphans
+  hs-source-dirs:
+    benchmark
+  main-is:
+    Bench.hs
+  build-depends:
+    data-dword,
+    Decimal,
+    deepseq,
+    fixed-decimal,
+    tasty-bench

--- a/src/Data/Fixed/Decimal.hs
+++ b/src/Data/Fixed/Decimal.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
 
 module Data.Fixed.Decimal

--- a/src/Data/Fixed/Decimal.hs
+++ b/src/Data/Fixed/Decimal.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 
+-- | Decimal types of fixed precision and scale
+--   which can use any 'Integral' type to store mantissa
 module Data.Fixed.Decimal
 (
     module Data.Fixed.Decimal.Class,
@@ -13,10 +15,15 @@ import Data.List (foldl')
 import Data.Ratio (denominator, numerator, (%))
 import GHC.TypeLits (KnownNat(..), Nat, natVal)
 
-
+-- | Decimal type of fixed precision and scale which uses:
+--
+--   * @Integral p => p@ type to store mantissa
+--   * Type-level number @s :: Nat@ to define scale (fractional part length)
+--
 newtype Decimal (p :: Type) (s :: Nat) = Decimal {
     mantissa :: p
 } deriving (Eq, Ord)
+
 
 instance (Integral m, KnownNat s) => FixedDecimal (Decimal m s) where
     type Scale (Decimal m s) = s

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
 import qualified Data.Decimal as DD


### PR DESCRIPTION
- Switch to `tasty` for tests
- Add `tasty-bench`-based benchmarks:  
  - For all basic functions comparing:
  - `Data.Fixed.Decimal`: with various precision;
  - `Data.Decimal`: slow but infinitely precise
  - `Double`: (as a baseline) fastest but not gives incorrect results
- Run benchmarks on all (three) supported platforms in CI 
- Update documentation on `docs` branch on tag push:  
  - Latest generated `Haddock` documentation
  - Latest benchmark results