### PR TITLE
Various fixes + more tests and benchmarks

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -160,6 +160,7 @@ jobs:
       run: |
         npm i -g badge-maker
         badge version "${{ env.VERSION }}" :green > "${{ env.DOCS_DIR }}/version.svg"
+        badge haddock "${{ env.VERSION }}" "#5E5184" > "${{ env.DOCS_DIR }}/haddock.svg"
         badge bench-linux "${{ env.VERSION }}" "#E95420" > "${{ env.DOCS_DIR }}/bench-linux.svg"
         badge bench-windows "${{ env.VERSION }}" "#01BCF3" > "${{ env.DOCS_DIR }}/bench-windows.svg"
         badge bench-macos "${{ env.VERSION }}" "#A2AAAD" > "${{ env.DOCS_DIR }}/bench-macos.svg"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -124,7 +124,7 @@ jobs:
     - name: Run benchmarks
       run: |
         mkdir ${{ env.BENCH_DIR }}
-        stack bench --ba '--csv ${{ env.BENCH_DIR }}/results.csv --svg ${{ env.BENCH_DIR }}/results.svg +RTS -T'
+        stack bench --ba '-o ${{ env.BENCH_DIR }}/results.html --csv ${{ env.BENCH_DIR }}/results.csv'
 
     - name: Upload ${{ matrix.os }} benchmarks results
       uses: actions/upload-artifact@v3
@@ -162,6 +162,7 @@ jobs:
         badge version "${{ env.VERSION }}" :green > "${{ env.DOCS_DIR }}/version.svg"
         badge bench-linux "${{ env.VERSION }}" "#E95420" > "${{ env.DOCS_DIR }}/bench-linux.svg"
         badge bench-windows "${{ env.VERSION }}" "#01BCF3" > "${{ env.DOCS_DIR }}/bench-windows.svg"
+        badge bench-macos "${{ env.VERSION }}" "#A2AAAD" > "${{ env.DOCS_DIR }}/bench-macos.svg"
         git add ${{ env.DOCS_DIR }}/*
         git -c "user.name=Auto Publisher" -c "user.email=eduard.sergeev@gmail.com" commit --allow-empty -m "Build ${{ env.VERSION }}"
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![Test Coverage](https://coveralls.io/repos/github/EduardSergeev/fixed-decimal/badge.svg)](https://coveralls.io/github/EduardSergeev/fixed-decimal)
 [![Documentation](https://eduardsergeev.github.io/fixed-decimal/version.svg)](https://eduardsergeev.github.io/fixed-decimal/haddock/)
 
-
 Fixed precision decimals for Haskell
 
 # Benchmarks
 
-[![Linux benchmarks](https://eduardsergeev.github.io/fixed-decimal/bench-linux.svg)](https://eduardsergeev.github.io/fixed-decimal/ubuntu-latest/results.svg)
-[![Windows benchmarks](https://eduardsergeev.github.io/fixed-decimal/bench-windows.svg)](https://eduardsergeev.github.io/fixed-decimal/windows-latest/results.svg)
+[![Linux benchmarks](https://eduardsergeev.github.io/fixed-decimal/bench-linux.svg)](https://eduardsergeev.github.io/fixed-decimal/ubuntu-latest/results.html)
+[![Windows benchmarks](https://eduardsergeev.github.io/fixed-decimal/bench-windows.svg)](https://eduardsergeev.github.io/fixed-decimal/windows-latest/results.html)
+[![MacOS benchmarks](https://eduardsergeev.github.io/fixed-decimal/bench-macos.svg)](https://eduardsergeev.github.io/fixed-decimal/macos-latest/results.html)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,87 @@
 
 [![Build Status](https://github.com/EduardSergeev/fixed-decimal/actions/workflows/master.yml/badge.svg?branch=master)](https://github.com/EduardSergeev/fixed-decimal/actions?query=workflow%3Amaster+branch%3Amaster)
 [![Test Coverage](https://coveralls.io/repos/github/EduardSergeev/fixed-decimal/badge.svg)](https://coveralls.io/github/EduardSergeev/fixed-decimal)
-[![Documentation](https://eduardsergeev.github.io/fixed-decimal/version.svg)](https://eduardsergeev.github.io/fixed-decimal/haddock/)
+[![Documentation](https://eduardsergeev.github.io/fixed-decimal/haddock.svg)](https://eduardsergeev.github.io/fixed-decimal/haddock/)
 
-Fixed precision decimals for Haskell
+[Fixed-precision decimals](https://en.wikipedia.org/wiki/Fixed-point_arithmetic) for Haskell
+
+# How to use it
+
+The core of this library is type `Decimal (m :: Type) (s :: Nat)` which expects two arguments:
+
+- Integral `m :: Type` to store mantissa:  
+  Any `Integral` type can be passed as `m` parameter: standard `Int`, [double-word](https://hackage.haskell.org/package/data-dword)'s signed `Int256` or unsigned `Word128` or even `Integer` for mantissa or arbitrary length;
+- Type-level number `s :: Nat` which specifies the fractional part size (in decimal digits).
+
+The following example defines decimal number type which uses (signed) 256 bits to store mantissa with 10-digit fractional part:
+
+```haskell
+{-# LANGUAGE DataKinds #-}
+
+import Data.DoubleWord (Int256)
+import Data.Fixed.Decimal (Decimal)
+
+type DecimalI256 = Decimal Int256 10
+```
+
+Minimum and maximum values which can be stored for various `Decimal m s` flavours:
+
+```haskell
+>>> minBound :: Decimal Int 5
+-92233720368547.75808
+
+>>> maxBound :: Decimal Int256 25
+5789604461865809771178549250434395392663499233282028.2019728792003956564819967
+
+>>> minBound :: Decimal Word128 10
+0
+
+>>> maxBound :: Decimal Word128 10
+34028236692093846346337460743.1768211455
+```
+
+To use mantissa of arbitrary length use `Integer`:
+
+```haskell
+>>> 1 / 3 :: Decimal Integer 50
+0.33333333333333333333333333333333333333333333333333
+```
+
+# Why
+
+In comparison to floating-point numeric data types like `Float` or `Double` fixed-precision decimals can store decimal numbers with exact precision.  
+
+For example `Double` cannot represent number `0.01` exactly:
+
+```haskell
+>>> sum $ replicate 10 (0.01 :: Double)
+9.999999999999999e-2
+
+>>> sum $ replicate 100 (0.01 :: Double)
+1.0000000000000007
+```
+
+while `Decimal m s` can:
+
+```haskell
+>>> sum $ replicate 10 (0.01 :: Decimal Int 2)
+0.1
+
+>>> sum $ replicate 100 (0.01 :: Decimal Int 2)
+1
+```
+
+# Overflows and performance
+
+In spirit of other Haskell numeric types `Decimal m s` does not detect or handle numeric overflows, i.e. when the result of operation cannot be represented using the supplied `m :: Type` mantissa type or `s :: Nat`-digits fractional part. In such case no error will be thrown while the resulting number will be incorrect.  
+The only way to avoid this situation is to select appropriate `m` and `s`: large enough to store any possible results.  
+NB: Smaller `m :: Type` however exhibit better performance, e.g. `Decimal Int 5` will be more performant that `Decimal Int256 5` and much better then `Decimal Integer 5`
+
 
 # Benchmarks
 
 [![Linux benchmarks](https://eduardsergeev.github.io/fixed-decimal/bench-linux.svg)](https://eduardsergeev.github.io/fixed-decimal/ubuntu-latest/results.html)
 [![Windows benchmarks](https://eduardsergeev.github.io/fixed-decimal/bench-windows.svg)](https://eduardsergeev.github.io/fixed-decimal/windows-latest/results.html)
 [![MacOS benchmarks](https://eduardsergeev.github.io/fixed-decimal/bench-macos.svg)](https://eduardsergeev.github.io/fixed-decimal/macos-latest/results.html)
+
+Benchmarks for various flavours of `Decimal m s` plus the results for the same benchmarks for `Double` and [Decimal](https://hackage.haskell.org/package/Decimal)

--- a/benchmark/Bench.hs
+++ b/benchmark/Bench.hs
@@ -1,58 +1,96 @@
+{-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
 
-import           Control.Arrow ((&&&))
-import           Control.DeepSeq (NFData)
+import           Control.DeepSeq (NFData, force)
 import qualified Data.Decimal as DD
-import           Data.DoubleWord
+import           Data.DoubleWord (Int128, Int256, Word128, Word256)
 import qualified Data.Fixed.Decimal as FD
 import           Data.List (foldl')
+import           Data.Ratio
+import           Data.Typeable (Typeable, typeOf)
+import           Data.Word (Word64)
 import           Test.Tasty.Bench
+import           Test.Tasty.Patterns.Printer (printAwkExpr)
 import           Text.Printf (printf)
-
-
-
-benchmarks :: [Benchmark]
-benchmarks =
-    fmap (uncurry benchmark . (show &&& id))  [
-        1000
-    ]
-
-benchmark :: String -> Int -> Benchmark
-benchmark t n =
-    bgroup t [
-        bgroup "Data.Fixed.Decimal" [
-            group "Decimal Int128 10" n (0.001 :: FD.Decimal Int128 10),
-            group "Decimal Int256 10" n (0.001 :: FD.Decimal Int256 10)
-        ],
-        group "Data.Decimal" n (0.001 :: DD.Decimal),
-        group "Double" n (0.001 :: Double)
-    ]
-
-group :: (NFData a, Fractional a) => String -> Int -> a -> Benchmark
-group t n d =
-    bgroup t [
-        bdef "+" $
-            nf (\n' -> sum $ replicate n' d) n,
-        bdef "-" $
-            nf (\n' -> foldl' (-) (fromIntegral n' * d) $ replicate n' d) n,
-        bdef "*" $
-            nf (\n' -> product $ replicate n' d) n,
-        bdef "/" $        
-            nf (\n' -> foldl' (/) (d ^ n') $ replicate n' d) n
-    ]
-    where
-        bdef o =
-            bench $ printf "%s (%dx times)" o n
 
 
 deriving instance NFData p => NFData (FD.Decimal p s)
 
+instance NFData Int128 where
 instance NFData Int256 where
 
-instance NFData Int128 where
-
 instance NFData Word128 where
+instance NFData Word256 where
+
+
+benchmarks :: [Benchmark]
+benchmarks = [
+        benchmark 1000 (1.001)
+    ]
+
+benchmark :: Int -> Rational -> Benchmark
+benchmark n r =
+    bgroup tn [
+        group (toD r :: Double),
+        bgroup "Data.Fixed.Decimal" [
+            bgroup "signed" [
+                group @(FD.Decimal Int 5) (toD r),
+                group @(FD.Decimal Int128 10) (toD r),
+                group (toD r :: FD.Decimal Int256 25),
+                group (toD r :: FD.Decimal Integer 50)
+            ],
+            bgroup "unsigned" [
+                group (toD r :: FD.Decimal Word64 5),
+                group (toD r :: FD.Decimal Word128 5),
+                group (toD r :: FD.Decimal Word256 15)
+            ]
+        ],
+        group (toD r :: DD.Decimal)
+    ]
+    where
+        baseline = show . typeOf $ (toD r :: Double)
+        tn = printf "%f x %d times" (fromRational @Double r) n
+
+        toD :: Fractional d => Rational -> d
+        toD = fromRational
+
+        group :: forall d. (NFData d, Fractional d, Real d, Enum d, Typeable d, Show d) => d -> Benchmark
+        group d =
+            bgroup (show $ typeOf d) [
+                bdef "+" $
+                    nf sum ds,
+                bdef "-" $
+                    nf (foldl' (-) (fromIntegral n * d)) ds,
+                bdef "*" $
+                    nf product ds,
+                bdef "/" $        
+                    nf (foldl' (/) (d ^ n)) ds,
+                bdef "abs" $
+                    nf (fmap abs) fs,
+                bdef "signum" $
+                    nf (fmap signum) fs,
+                bdef "fromRational" $
+                    nf (fmap (fromRational @d)) fs,
+                bdef "toRational" $
+                    nf (fmap toRational) d2s,
+                bdef "show" $
+                    nf (fmap show) d2s
+            ]
+            where
+                ds = force $ replicate n d
+                fs = force [ (1 % dn) | dn <- [fromIntegral (-n) `div` 2 .. fromIntegral n `div` 2], dn /= 0 ]
+                d2s = force [(d * fromIntegral n) .. (d * fromIntegral (n * n))]
+                gn = show $ typeOf d
+                bdef o
+                    | gn == baseline =
+                        bench bn
+                    | otherwise = 
+                        bcompare (printAwkExpr (locateBenchmark [bn, baseline, tn])) . (bench bn)
+                    where
+                        bn = printf "%s (%dx times)" o n :: String
 
 
 main :: IO ()

--- a/fixed-decimal.cabal
+++ b/fixed-decimal.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:           fixed-decimal
-version:        0.0.1
+version:        0.0.2
 synopsis:       Fixed precision decimals for Haskell
 description:
   Fixed precision decimal numbers type
@@ -11,11 +11,19 @@ description:
   >{-# LANGUAGE DataKinds #-}
   >
   >import Data.DoubleWord (Int256)
-  >import Data.Fixed.Decimal as (Decimal)
+  >import Data.Fixed.Decimal (Decimal)
   >
   >type DecimalI256 = Decimal Int256 10
   .
-  
+  >>> minBound :: Decimal Int 5
+  -92233720368547.75808
+  .
+  >>> maxBound :: Decimal Int256 25
+  5789604461865809771178549250434395392663499233282028.2019728792003956564819967
+  .
+  >>> 1 / 3 :: Decimal Integer 50
+  0.33333333333333333333333333333333333333333333333333
+  .
 
 category:       Data
 homepage:       https://github.com/EduardSergeev/fixed-decimal#readme

--- a/fixed-decimal.cabal
+++ b/fixed-decimal.cabal
@@ -63,11 +63,13 @@ test-suite fixed-decimal-test
   main-is: Test.hs
   other-modules:
     Paths_fixed_decimal
+    Data.Fixed.Decimal.Tests
   autogen-modules:
     Paths_fixed_decimal
   hs-source-dirs:
     test
-  ghc-options: -fno-warn-orphans -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:
+    -fno-warn-orphans -threaded -rtsopts -with-rtsopts=-N
   build-depends:
     data-dword,
     Decimal,
@@ -93,4 +95,5 @@ benchmark all
     Decimal,
     deepseq,
     fixed-decimal,
+    tasty,
     tasty-bench

--- a/fixed-decimal.cabal
+++ b/fixed-decimal.cabal
@@ -91,9 +91,8 @@ benchmark all
   main-is:
     Bench.hs
   build-depends:
+    criterion,
     data-dword,
     Decimal,
     deepseq,
-    fixed-decimal,
-    tasty,
-    tasty-bench
+    fixed-decimal

--- a/src/Data/Fixed/Decimal.hs
+++ b/src/Data/Fixed/Decimal.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Decimal types of fixed precision and scale
 --   which can use any 'Integral' type to store mantissa
@@ -15,15 +15,15 @@ module Data.Fixed.Decimal
 import Data.Fixed.Decimal.Class
 import Data.Kind (Type)
 import Data.Ratio (denominator, numerator, (%))
-import GHC.TypeLits -- (KnownNat, Nat, natVal, (^))
+import GHC.TypeLits (KnownNat, Nat, natVal, type (^))
 
 -- | Decimal type of fixed precision and scale which uses:
 --
---   * 'p': 'Integral' type to store mantissa
+--   * 'm': 'Integral' type to store mantissa
 --   * 's': Type-level number 'Nat' to define scale (fractional part size)
 --
-newtype Decimal (p :: Type) (s :: Nat) = Decimal {
-    mantissa :: p
+newtype Decimal (m :: Type) (s :: Nat) = Decimal {
+    mantissa :: m
 } deriving (Eq, Ord)
 
 

--- a/src/Data/Fixed/Decimal.hs
+++ b/src/Data/Fixed/Decimal.hs
@@ -17,8 +17,8 @@ import GHC.TypeLits (KnownNat(..), Nat, natVal)
 
 -- | Decimal type of fixed precision and scale which uses:
 --
---   * @Integral p => p@ type to store mantissa
---   * Type-level number @s :: Nat@ to define scale (fractional part length)
+--   * 'p': 'Integral' type to store mantissa
+--   * 's': Type-level number 'Nat' to define scale (fractional part size)
 --
 newtype Decimal (p :: Type) (s :: Nat) = Decimal {
     mantissa :: p

--- a/src/Data/Fixed/Decimal.hs
+++ b/src/Data/Fixed/Decimal.hs
@@ -1,5 +1,8 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 -- | Decimal types of fixed precision and scale
 --   which can use any 'Integral' type to store mantissa
@@ -11,9 +14,8 @@ module Data.Fixed.Decimal
 
 import Data.Fixed.Decimal.Class
 import Data.Kind (Type)
-import Data.List (foldl')
 import Data.Ratio (denominator, numerator, (%))
-import GHC.TypeLits (KnownNat(..), Nat, natVal)
+import GHC.TypeLits -- (KnownNat, Nat, natVal, (^))
 
 -- | Decimal type of fixed precision and scale which uses:
 --
@@ -29,45 +31,48 @@ instance (Integral m, KnownNat s) => FixedDecimal (Decimal m s) where
     type Scale (Decimal m s) = s
     type Precision (Decimal m s) = m
     scale _ =
-        fromInteger $ natVal @s undefined
+        fromIntegral $ natVal @s undefined
     decimal m e =
-        let ma = normalise $ fromIntegral m * (10 ^ (scale @(Decimal m s) undefined + e + 1))
-        in Decimal ma
+        Decimal $ fromIntegral m * (10 ^ (scale @(Decimal m s) undefined + e))
+
+type Scale10 (s :: Nat) = 10 ^ s
+
+scale10 :: forall s i m. (KnownNat (10 ^ s), Integral i) => (Decimal m s) -> i
+scale10 _ =
+    fromInteger $ natVal @(Scale10 s) undefined
+
 
 instance (Show m, Integral m, KnownNat s) => Show (Decimal m s) where
     show (Decimal 0) =
         "0"
-    show dm@(Decimal m) =
-        fst . foldl' step ([], scale dm) . pad (scale dm + 1) . reverse . show $ m
+    show dl@(Decimal dm) =
+        let ds = gof (scale dl) (reverse . sabs . show $ dm) []
+        in if dm < 0 then '-' : ds else ds
         where
-            step ([], i) '0' | i > 0 =
-                ([], i - 1)
-            step (ds, i) d | i > 0 =
-                (d : ds, i - 1)
-            step ([], 0) d =
-                ([d], -1)
-            step (ds, 0) d =
-                (d : '.' : ds, -1)
-            step (ds, i) d  =
-                (d : ds, i - 1)
-            pad 0 ds =
+            sabs ('-': ds) =
                 ds
-            pad i [] =
-                '0' : pad (pred i) []
-            pad i "-" =
-                '0' : pad (pred i) "-"
-            pad i (d : ds) =
-                d : pad (pred i) ds
+            sabs ds =
+                ds
 
-normalise :: Integral a => a -> a
-normalise i =
-    case i `quotRem` 10 of
-        (q, r) | abs r < 5 -> q
-        (q, _) | q > 0 -> succ q
-        (q, _) -> pred q
+            gof 0 ds [] =
+                goi ds []
+            gof 0 ds rs =
+                goi ds ('.' : rs)
+            gof i ('0' : ds) [] =
+                gof (pred i) ds [] 
+            gof i (d : ds) rs =
+                gof (pred i) ds (d : rs)
+            gof i [] rs =
+                gof (pred i) [] ('0' : rs)
 
+            goi [] rs@('.' : _) =
+                '0' : rs
+            goi [] rs =
+                rs
+            goi (d : ds') rs =
+                goi ds' (d : rs)
 
-instance (Integral m, KnownNat s) => Num (Decimal m s) where
+instance (Integral m, KnownNat s, KnownNat (10 ^ s)) => Num (Decimal m s) where
     (Decimal l) + (Decimal r) =
         Decimal $ l + r
 
@@ -75,24 +80,24 @@ instance (Integral m, KnownNat s) => Num (Decimal m s) where
         Decimal $ l - r
 
     (Decimal l) * d@(Decimal r) =
-        Decimal . normalise $ l * r `div` (10 ^ (scale d - 1))
+        Decimal $ l * r `div` scale10 d
 
     abs (Decimal m) =
         Decimal $ abs m
 
     signum d@(Decimal m) =
-        Decimal $ (10 ^ scale d) * signum m
+        Decimal $ scale10 d * signum m
 
     fromInteger i =
-        Decimal $ (10 ^ scale (undefined :: Decimal m s)) * fromInteger i
+        Decimal $ scale10 (undefined :: Decimal m s) * fromInteger i
 
 
-instance (Show m, Integral m, KnownNat s) => Fractional (Decimal m s) where
-  fromRational r =
-    fromInteger (numerator r) / fromInteger (denominator r)
+instance (Show m, Integral m, KnownNat s, KnownNat (10 ^ s)) => Fractional (Decimal m s) where
+    fromRational r =
+        fromInteger (numerator r) / fromInteger (denominator r)
 
-  (Decimal l) / d@(Decimal r) =
-    Decimal . normalise $ (10 ^ (scale d + 1)) * l `div` r
+    (Decimal l) / d@(Decimal r) =
+        Decimal $ scale10 d * l `div` r
     
 instance (Bounded m) => Bounded (Decimal m s) where
     minBound =
@@ -101,6 +106,20 @@ instance (Bounded m) => Bounded (Decimal m s) where
         Decimal $ maxBound @m
 
 
-instance (Integral m, KnownNat s) => Real (Decimal m s) where
+instance (Integral m, KnownNat s, KnownNat (10 ^ s)) => Real (Decimal m s) where
     toRational d@(Decimal m) =
-        fromIntegral m % (10 ^ scale d)
+        (fromIntegral m) % (scale10 d)
+
+instance (Enum m, Integral m, KnownNat s, KnownNat (10 ^ s)) => Enum (Decimal m s) where
+    fromEnum d@(Decimal m) =
+        fromEnum $ m `div` (scale10  d)
+    toEnum =
+        fromIntegral
+    enumFrom =
+        iterate (+1)
+    enumFromThen x1 x2 =
+        let dx = x2 - x1 in iterate (+dx) x1
+    enumFromTo x1 x2 =
+        takeWhile (<= x2) $ enumFrom x1
+    enumFromThenTo x1 x2 x3 =
+        takeWhile (<= x3) $ enumFromThen x1 x2

--- a/src/Data/Fixed/Decimal/Class.hs
+++ b/src/Data/Fixed/Decimal/Class.hs
@@ -9,9 +9,15 @@ module Data.Fixed.Decimal.Class
 import Data.Kind (Type)
 import GHC.TypeLits (Nat)
 
-
+-- | Fixed decimal types class
 class FixedDecimal d where
+    -- | 'Integral' type for storing mantissa 
     type Precision d :: Type
+    -- | The size of the fractional part in decimal digits
     type Scale d :: Nat
+    -- | Runtime value of @Scale d@
     scale :: d -> Int
-    decimal :: Integral i => i -> Int -> d
+    -- | Value constructor
+    --
+    -- @decimal m e@ constructs a decimal number via @m * 10 '^^' e@.
+    decimal :: Integral m => m -> Int -> d

--- a/test/Data/Fixed/Decimal/Tests.hs
+++ b/test/Data/Fixed/Decimal/Tests.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Data.Fixed.Decimal.Tests
+(
+    testFor
+) where
+
+import qualified Data.Decimal as DD
+import           Data.Fixed.Decimal
+import           Data.Scientific (Scientific(..), scientific)
+import           Data.Typeable (Typeable, typeOf)
+import           GHC.TypeLits (KnownNat, type (^))
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.HUnit (testCase, (@?=))
+import           Test.Tasty.QuickCheck hiding (scale)
+
+
+testFor :: forall m s. (Integral m, Typeable m, KnownNat s, KnownNat (10 ^ s), Show m) => Decimal m s -> Decimal m s -> TestTree
+testFor dmin dmax =
+    testGroup (show $ typeOf dmin) [
+        testGroup "QuickCheck tests" [
+            testGroup "Roundtrip tests" [
+                testProperty "Scientific roundtrip"
+                    prop_sientificEq,
+                testProperty "Rational roundtrip"
+                    prop_rationalEq,
+                testProperty "Precision test"
+                    prop_precision  
+            ],
+    testGroup "Behaviour equivalence tests" [
+            testProperty "/ * test"
+                prop_divisionMultiplication,
+            testProperty "DD.Decimal equivalence in terms of addition"
+                prop_decimalPlusEq,
+            testProperty "show" $ do
+                d <- gen
+                pure $ show (fromDecimal @DD.Decimal d) === show d,
+            testProperty "abs" $ do
+                d <- gen
+                pure $ show (fromDecimal @DD.Decimal d) === show (abs d),
+            testProperty "signum" $ do
+                d <- gen
+                pure $ (show . signum @DD.Decimal . fromDecimal) d === (show . signum) d
+      ]
+    ],
+    testGroup "Specific Show cases" [
+        testCase "0" $
+            show (0 :: Decimal m s) @?= "0",
+        testCase "42" $
+            show (42 :: Decimal m s) @?= "42",
+        testCase "42.1" $
+            show (42.1 :: Decimal m s) @?= "42.1",
+        testCase "-42.01" $
+            show (-42.01 :: Decimal m s) @?= "-42.01",
+      testCase "-42.00042" $
+          show (-42.00042 :: Decimal m s) @?= "-42.00042"
+    ]
+  ]
+    where
+        gen :: Gen (Decimal m s)
+        gen = do
+            r <- Decimal . (* (10 ^ ((s `div` 2 + 1)))) . fromInteger <$> chooseInteger (minLim, maxLim)
+            pure r
+            where
+                s = scale dmax
+                p = floor @Double @Int . logBase 10 . fromIntegral . mantissa $ dmax
+                minLim = toInteger $ mantissa dmin `mod` (10 ^ (p `div` 3))        
+                maxLim = toInteger $ mantissa dmax `mod` (10 ^ (p `div` 3))        
+
+        prop_sientificEq = do
+            d <- gen
+            pure $ d === (fromScientific . toScientific) d
+
+        prop_rationalEq = do
+            d <- gen
+            pure $ d === (fromRational @(Decimal m s) . toRational $ d)
+
+        prop_divisionMultiplication = do
+            a <- gen
+            b <- gen
+            pure $ a /= 0 && b /= 0 ==> (a * b / a === b) .&&. (a * b / b === a)
+
+        prop_decimalPlusEq = do
+            dl <- gen
+            dr <- gen
+            let l = toRational dl
+                r = toRational dr
+                el = fromRational @DD.Decimal l
+                er = fromRational @DD.Decimal r
+            pure $ toRational (el + er) === toRational (dl + dr) 
+            where
+
+        prop_precision :: (Positive Int) -> (Positive Int) -> Property
+        prop_precision (Positive n) (Positive di) =
+            let d = fromIntegral @_ @Double di / 1000.0
+                de = fromIntegral @_ @(Decimal m s) di / 1000
+            in viaSum d /= (fromIntegral n) * d ==> viaSum de === (fromIntegral n) * de 
+            where
+                viaSum d = sum $ replicate n d
+
+        toScientific :: Decimal m s -> Scientific
+        toScientific d =
+            scientific (fromIntegral . mantissa $ d) (negate . scale $ d)
+
+        fromScientific :: Scientific -> Decimal m s
+        fromScientific s =
+            decimal (coefficient s) (base10Exponent s)
+
+        fromDecimal :: Fractional a => Decimal m s -> a
+        fromDecimal =
+            fromRational . toRational

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,119 +1,19 @@
-{-# LANGUAGE TypeSynonymInstances #-}
+import Data.DoubleWord (Int128, Int256)
+import Data.Fixed.Decimal (Decimal)
+import Data.Fixed.Decimal.Tests (testFor)
+import Test.Tasty (TestTree, defaultMain, testGroup)
 
-import qualified Data.Decimal as DD
-import           Data.DoubleWord (Int256)
-import           Data.Fixed.Decimal hiding (Decimal)
-import qualified Data.Fixed.Decimal as D
-import           Data.Scientific (Scientific(..), scientific)
-import           Test.QuickCheck.Instances.Scientific ()
-import           Test.Tasty (TestTree, defaultMain, testGroup)
-import           Test.Tasty.HUnit (testCase, (@?=))
-import           Test.Tasty.QuickCheck hiding (scale)
-
-
-type FractionalPartPrecision = 15
-type Decimal = D.Decimal Int256 FractionalPartPrecision
 
 tests :: TestTree
 tests =
-  testGroup "Decimal tests" [
-    testGroup "QuickCheck tests" [
-      testGroup "Roundtrip tests" [
-        testProperty "Scientific roundtrip"
-          prop_sientificEq,
-        testProperty "Rational roundtrip"
-          prop_rationalEq,
-        testProperty "Precision test"
-          prop_precision  
-      ],
-      testGroup "Behaviour equivalence tests" [
-        testProperty "/ * test"
-          prop_divisionMultiplication,
-        testProperty "DD.Decimal equivalence in terms of addition"
-          prop_decimalPlusEq,
-        testProperty "show" $
-          \e -> show @DD.Decimal e === (show . fromRational @Decimal . toRational) e,
-        testProperty "abs" $
-          \e -> (show . abs @DD.Decimal) e === (show . abs . fromRational @Decimal . toRational) e,
-        testProperty "signum" $
-          \e -> (show . signum @DD.Decimal) e === (show . signum . fromRational @Decimal . toRational) e
-      ]
-    ],
-    testGroup "Specific Show cases" [
-      testCase "0" $
-          show (0 :: Decimal) @?= "0",
-      testCase "42" $
-          show (42 :: Decimal) @?= "42",
-      testCase "42.1" $
-          show (42.1 :: Decimal) @?= "42.1",
-      testCase "-42.0000001" $
-          show (-42.0000001 :: Decimal) @?= "-42.0000001",
-      testCase "0.00000042" $
-          show (0.00000042 :: Decimal) @?= "0.00000042",
-      testCase "-0.00000042" $
-          show (-0.00000042 :: Decimal) @?= "-0.00000042"
-    ]
+  testGroup "Data.Fixed.Decimal" [
+    testFor (minBound :: Decimal Int 5) maxBound,
+    testFor (minBound :: Decimal Int128 10) maxBound,
+    testFor (minBound :: Decimal Int256 25) maxBound,
+    testFor
+      (fromRational @(Decimal Integer 25) . toRational $ (minBound :: Decimal Int256 25))
+      (fromRational @(Decimal Integer 25) . toRational $ (maxBound :: Decimal Int256 25))
   ]
-
-prop_sientificEq :: Scientific -> Property
-prop_sientificEq s =
-  inRange s ==> s === (toScientific . fromScientific) s
-
-prop_rationalEq :: Scientific -> Property
-prop_rationalEq s =
-    inRange s ==> s === (fromRational . toRational . fromRational @Decimal . toRational) s
-
-prop_divisionMultiplication :: Decimal -> Decimal -> Property
-prop_divisionMultiplication a b =
-    (a * b / a === b) .&&. (a * b / b === a)
-
-prop_decimalPlusEq :: Decimal -> Decimal -> Property
-prop_decimalPlusEq dl dr =
-    toRational (el + er) === toRational (dl + dr) 
-    where
-        l = toRational dl
-        r = toRational dr
-        el = fromRational @DD.Decimal l
-        er = fromRational @DD.Decimal r
-
-prop_precision :: (Positive Int) -> (Positive Int) -> Property
-prop_precision (Positive n) (Positive di) =
-    let d = fromIntegral @_ @Double di / 1000.0
-        de = fromIntegral @_ @Decimal di / 1000
-    in viaSum d /= (fromIntegral n) * d ==> viaSum de === (fromIntegral n) * de 
-    where
-        viaSum d = sum $ replicate n d
-
-
-inRange :: Scientific -> Bool
-inRange s =
-    s >= toScientific minBound &&
-    s <= toScientific maxBound &&
-    base10Exponent s > -lim &&
-    base10Exponent s < lim - 1
-    where
-        lim = scale (undefined :: Decimal)
-
-toScientific :: Decimal -> Scientific
-toScientific d =
-    scientific (fromIntegral . mantissa $ d) (negate . scale $ d)
-
-fromScientific :: Scientific -> Decimal
-fromScientific s =
-    decimal (coefficient s) (base10Exponent s)
-
-
-instance Arbitrary Decimal where
-    arbitrary =
-        D.Decimal . (* (10 ^ ((s `div` 2 + 1)))) <$> chooseBoundedIntegral (-lim, lim)
-        where
-            s = scale @Decimal undefined
-            p = floor @Double @Int . logBase 10 . fromIntegral $ maxBound @(Precision Decimal)
-            lim = maxBound @(Precision Decimal) `mod` (10 ^ (p `div` 3))
-
-instance Arbitrary DD.Decimal where
-    arbitrary = flip suchThat (\d -> let sd = show d in '.' `notElem` sd || last sd /= '0') $ do
-        fromRational . toRational <$> arbitrary @Decimal
 
 
 main :: IO ()


### PR DESCRIPTION
- Fixed:
  - Get rid of `normalise` function:  
    No need to normilise the result assuming there were no overflow
- Changed:
  - More tests:  
    Test various flavours of `Decimal m s` including `m :: Int` and `m :: Integer`
  - More benchmarks:
    - Switch to [criterion](http://www.serpentine.com/criterion) for benchmarking
    - Use generic set of benchmarks against various fractional types:
      - `Double` which is used as baseline to compare other benchmarks against
      - `Decimal Int* s`, `Decimal Word* s` and `Decimal Integer s`
      - External `Data.Decimal` which provides arbitrary precision  